### PR TITLE
Fixed minimal R version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,11 +29,11 @@ Authors@R: c(person("Keon-Woong", "Moon", role = c("aut", "cre"),
            email="todoslogos@gmail.com"))
 URL: https://github.com/cardiomoon/webr
 BugReports: https://github.com/cardiomoon/webr/issues
-Description: Several analysis-related functions for the book entitled 
-    "Web-based Analysis without R in Your Computer"(written in Korean, ISBN 978-89-5566-185-9) 
-    by Keon-Woong Moon. The main function plot.htest() shows the distribution of statistic for 
+Description: Several analysis-related functions for the book entitled
+    "Web-based Analysis without R in Your Computer"(written in Korean, ISBN 978-89-5566-185-9)
+    by Keon-Woong Moon. The main function plot.htest() shows the distribution of statistic for
     the object of class 'htest'.
-Depends: R(>= 2.10)    
+Depends: R (>= 2.1.0)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
There is a small typo in your DESCRIPTION file, which makes it impossible to install the package from GitHub (see [SO](https://stackoverflow.com/questions/55590715/error-invalid-comparison-operator-in-dependency-when-installing-r-package)). I fixed the minimal R version dependency and removed a bit of  superfluous whitespace at the end of several lines.